### PR TITLE
Add Internet capitalisation rule to ghost-writing skill

### DIFF
--- a/skills/ghost-writing/SKILL.md
+++ b/skills/ghost-writing/SKILL.md
@@ -16,6 +16,7 @@ Determine whether the context is **formal** (specs, RFDs, Internet-Drafts), **se
 - Definitions before examples, with links as escape hatches for depth.
 - Consistent grammatical structure across list items and comparable elements.
 - Active voice preferred.
+- *Internet* (capital I) for the global network; *internet* (lowercase i) for a generic network of networks.
 - Oxford comma always.
 - List items end with a full stop (or other terminal punctuation).
 - Blank line before and after every list block.

--- a/skills/ghost-writing/SKILL.md
+++ b/skills/ghost-writing/SKILL.md
@@ -16,10 +16,14 @@ Determine whether the context is **formal** (specs, RFDs, Internet-Drafts), **se
 - Definitions before examples, with links as escape hatches for depth.
 - Consistent grammatical structure across list items and comparable elements.
 - Active voice preferred.
-- *Internet* (capital I) for the global network; *internet* (lowercase i) for a generic network of networks.
 - Oxford comma always.
 - List items end with a full stop (or other terminal punctuation).
 - Blank line before and after every list block.
+
+## Nomenclature
+
+- *Internet* (capital I) for the global network; *internet* (lowercase i) for a generic network of networks.
+- *Web* (capital W) for the World Wide Web; *web* (lowercase w) for a generic web or network.
 
 ## British English
 


### PR DESCRIPTION
The Internet (proper noun, the global network) takes a capital I;
an internet (generic network of networks) is lowercased. Added to
Core Rules so it applies across all formality contexts.