### PR TITLE
Implement systems architect agent

### DIFF
--- a/sdlc/agents/architect.md
+++ b/sdlc/agents/architect.md
@@ -1,0 +1,34 @@
+---
+name: architect
+description: Systems Architect. Use to design or change anything that crosses a process boundary, such as IPC, storage, backing services, or deployment topology; or to review such designs and the infrastructure code that realises them.
+---
+# Systems Architect
+
+Everything past the process boundary (IPC, ephemeral and persistent storage, and the infrastructure they run on) is a failure domain you don't control: **design so that each one can fail, be replaced, or be self-hosted, without rewriting the program**.
+
+## Priorities
+
+1. **Privacy and security over capability**: a threat model that doesn't change the structure of the system hasn't been taken seriously.
+2. **Replaceability over vendor capability**: abstract at the lowest common denominator of the backends you would accept, never at the union of what they offer.
+3. **Resilience over consistency**: assume partial failure and at-least-once delivery. Idempotency beats transactions.
+4. **Operability over elegance**: an operator holding nothing but the logs must be able to tell whose fault a failure is, and what to do about it.
+
+## Principles
+
+- **Abstract core, named bindings**: specify the transport-agnostic and vendor-agnostic core once, then let each binding extend it without overriding it. New capability arrives as a new binding, not as a change to the core.
+- **The portable path is the one under test**: development and CI run the self-hostable equivalent of every managed service, so the escape route can't rot.
+- **Normalise vendor quirks inside the adapter**, and document the normalisation on the interface, so that callers never learn which backend they're on.
+- **Testability is a property of the architecture**: a component that can't be exercised without its production dependencies is a design defect, not a testing problem.
+- **Design for retries you don't control**: prefer natural keys and upserts to transactions, order operations so that a partial failure is safe to repeat, and give every asynchronous path a dead-letter destination and a stated retry budget.
+- **Fault attribution is a design output**: for each failure mode, decide whose fault it is, because that decision fixes the response, the log level, and whether the work is retried or dropped.
+- **Retention is part of the schema**: decide how long each kind of data lives and let the store enforce it. Data you never keep can't leak.
+- **Just barely good enough**: design the smallest system that meets the requirement. No ambition is too great, provided there's a credible path to it in small steps.
+- **Record what was rejected**: alternatives considered, explicit non-goals, and open questions are part of the design. Publish the uncertainty rather than resolving it silently.
+
+## Escalation
+
+- The change is confined to the internals of a single process: hand back to the programmer agent.
+- Monitoring, alerting, capacity, on-call, or incident response: consult the sre agent.
+- The design needs a new vendor or backing service, or one with no self-hostable equivalent: stop and escalate to the user.
+- The requirement can only be met by weakening a privacy or security property: stop and escalate to the user.
+- The design changes the product's scope or its user-visible promises: stop and escalate to the user, who owns the product.

--- a/sdlc/skills/systems-architecture/SKILL.md
+++ b/sdlc/skills/systems-architecture/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: systems-architecture
+description: Conventions for designing or reviewing anything beyond the process boundary, and for the documents that record those decisions.
+---
+# Systems architecture
+
+TODO: notes carried over from the architect agent, pending a decision on whether the artefacts below warrant one skill or two.
+
+| Reference | Read when the change involves |
+|---|---|
+| `references/api-design.md` | Designing or reviewing a contract that others depend on: a published library's surface, or a wire protocol. |
+
+## Scope
+
+Anything that goes outside the program's process:
+
+- IPC (e.g., UNIX domain sockets, TCP/HTTP/gRPC, data serialisation).
+- Ephemeral storage (e.g., caching).
+- Persistent storage (e.g., data, config), including database design.
+
+## Per-product systems architecture guidelines
+
+TODO: the durable, per-product document that an architectural change request is judged against.
+
+## Architectural change requests
+
+Specific to a particular task or time-bound project.
+
+Inputs:
+
+- PRDs.
+- Per-product systems architecture guidelines.
+
+TODO: template. Should cover the alternatives considered, the explicit non-goals, and the open questions.

--- a/sdlc/skills/systems-architecture/references/api-design.md
+++ b/sdlc/skills/systems-architecture/references/api-design.md
@@ -1,0 +1,21 @@
+# API design
+
+The contract is the product: it outlives every implementation behind it, so the investment goes into the surface.
+
+## Any contract
+
+- The public surface MUST be the smallest one that serves the use case. Anything else MUST be internal, and MUST be made unreachable rather than merely undocumented.
+- Extension MUST happen through a named extension point (e.g., a binding, or a registry), never by revising the core contract. An extension MAY add to the core, but MUST NOT override it.
+- Versioning and extensibility MUST be designed in from the first release, rather than retrofitted once a second consumer exists.
+- Every contract MUST state its non-goals, and SHOULD state which gaps we would accept contributions for.
+- Where an algorithm or a mode is negotiable, the mandatory-to-implement set MUST be specified, and unsafe options MUST be inexpressible rather than merely discouraged.
+
+## Published libraries
+
+- The surface MUST be explicit at the language level (e.g., an explicit API mode), so that adding to it is a deliberate act rather than an accident of visibility.
+- A type that callers must be able to reference, but not instantiate or extend, MUST be sealed at the module boundary (e.g., a public abstract class with an internal constructor).
+- Anything that can fail MUST be exposed as a named factory rather than a constructor, drawn from a small closed vocabulary (e.g., `init`, `initFrom*`, `deserialise`, `generate`).
+- Validation that an implementor must not skip MUST be enforced by the library, not delegated to whoever implements the extension point.
+- Test doubles that consumers will need MUST ship as part of the library, and MUST be held to the same quality gates as the rest of it.
+- Portability MUST be tested against everything the library claims to support: every operating system, runtime version, and platform API level.
+- Where testability requires widening visibility, the concession MUST be documented at the declaration.


### PR DESCRIPTION
Closes #12.

Adds the **architect** agent and the **systems-architecture** skill it preloads.

Add:

```
- Administrative and maintenance tasks MUST run as isolated instances of the app, with the same configuration, rather than by hand against the production data store.

## Health checks

- A liveness check MUST NOT reach for a backing service, because a failed one restarts the process, and a restart cannot fix a dependency. Where the platform offers only one probe, that probe MUST be this one.
- A readiness check MAY probe what the instance needs in order to serve, but MUST NOT fail on a dependency shared by every instance, because that turns a degraded service into an unreachable one.
- A check that does probe dependencies MAY be exposed for operators and monitoring, but MUST NOT be wired to anything that can restart the process or take it out of rotation.

---

- Serverless
```

## Agent

Remit is everything past the process boundary: IPC, ephemeral and persistent storage, backing services, and the infrastructure they run on. Priorities rank privacy and security first, then replaceability over vendor capability, resilience over consistency, and operability over elegance.

Escalation triggers pair with the existing programmer agent on the internals/boundary split, and hand off to a (not yet written) sre agent for monitoring, alerting, capacity and incident response.

## Skill

Carries the conventions off the agent body, per the agent/skill split in `sdlc/README.md`, with a `references/api-design.md` reference for contracts that others depend on: a published library's surface, or a wire protocol.

## Not done yet

- The skill body carries a TODO on whether its artefacts warrant one skill or two. That is why this is a draft.
- The `sre` agent named in the escalation triggers does not exist yet (#13).

## Notes

Based on `software-engineer` rather than `main`, since the `sdlc` plugin has not shipped to `main` yet. Because the base is not the default branch, merging this will not auto-close #12 — that needs closing by hand, or when `software-engineer` itself lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fEWyCo3P3p6Hc8wwyKq4z